### PR TITLE
Accept custom renderer as parameter

### DIFF
--- a/example/withCustomRenderer.js
+++ b/example/withCustomRenderer.js
@@ -1,0 +1,15 @@
+const jdown = require('..');
+const fs = require('fs');
+const path = require('path');
+
+const outputFile = path.join(__dirname, 'contents.json');
+
+const customRender = {
+	link: (href, title, text) => {
+	  return `<a target="_blank" href="${href}" title="${title}">${text}</a>`
+	}
+};
+
+jdown('example/content', customRender).then(content => {
+	fs.writeFileSync(outputFile, JSON.stringify(content, null, 2), 'utf8');
+});

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const metalsmith = require('metalsmith');
 const markdown = require('metalsmith-markdown');
 const camelCase = require('camelcase');
+const marked = require('marked')
 
 const transformFileContents = (files, file) => {
 	files[file].contents = files[file].contents.toString('utf8');
@@ -69,10 +70,25 @@ const transform = () => (files, metalsmith, done) => {
 	done();
 };
 
-const jdown = dir => new Promise((resolve, reject) => {
+let renderer = new marked.Renderer({
+	/* default options */
+  smartypants: true,
+  smartLists: true,
+  gfm: true,
+  tables: true,
+  breaks: false,
+  sanitize: false,
+});
+
+const jdown = (dir, customRenderFunctions = {}) => new Promise((resolve, reject) => {
+	Object.keys(customRenderFunctions).map(key => {
+		if (typeof customRenderFunctions[key] === 'function') {
+			renderer[key] = customRenderFunctions[key];
+		}
+	});
 	metalsmith(path.resolve())
 		.source(dir)
-		.use(markdown())
+		.use(markdown({renderer}))
 		.use(transform())
 		.process((err, files) => {
 			if (err) {

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
 		"main": "src/index.js",
 		"license": "MIT",
 		"scripts": {
-			"example": "node example"
+				"example": "node example",
+				"withCustomRender": "node 'example/withCustomRenderer.js'"
 		},
 		"dependencies": {
+				"camelcase": "5.0.0",
 				"metalsmith": "2.3.0",
 				"metalsmith-auto-collections": "0.1.4",
-				"metalsmith-markdown": "0.2.2",
-				"camelcase": "5.0.0"
+				"metalsmith-markdown": "0.2.2"
 		},
 		"devDependencies": {
 				"serve": "^6.1.0",

--- a/readme.md
+++ b/readme.md
@@ -36,13 +36,29 @@ Where "path/to/markdown/content" is a directory containing markdown files or fol
 
 Use the generated JSON however you like, I recommend with a static site generator like [React Static](https://github.com/nozzle/react-static)! This way you can use the markdown files as a CMS and use the JSON in the build stage.
 
+## Custom renderers
+
+By default, jdown uses the default [marked](https://github.com/markedjs/marked) renderer, but you may pass in your own custom overrides to customize the built html. This can be useful for adding custom ids or CSS classes. In the example below you can see how you can make your links open in a new tab by default, by adding target="\_blank" to anchor tags. 
+
+```js
+const jdown = require('jdown');
+const renderer = {
+	link: (href, title, text) => {
+	  return `<a target="_blank" href="${href}" title="${title}">${text}</a>`
+	}
+};
+
+jdown('path/to/markdown/content', renderer).then(content => console.log(content));
+
+```
+
 ## Examples
 
 See the [examples](example/) directory of this repository. To test it yourself clone this repo, install the dependancies with `npm install`, modify some content and run `npm run example`.
 
 [danwebb.co](https://danwebb.co) is built using jdown and [React Static](https://github.com/nozzle/react-static) so see the static.config.js file in the [websites github repo](https://github.com/DanWebb/danwebb.co) for a real world example.
 
-There is also an example built into React Static that you can use to quickly get up and running  [here](https://github.com/nozzle/react-static/tree/master/examples/markdown). 
+There is also an example built into React Static that you can use to quickly get up and running  [here](https://github.com/nozzle/react-static/tree/master/examples/markdown).
 
 ## License
 


### PR DESCRIPTION
# WHAT

Adds the functionality to pass in custom render functions as a second optional parameter to `jdown`.

Also adds another example node script and updates the readme.

Thanks!